### PR TITLE
Exposes MidiDriver interface to allow different impls

### DIFF
--- a/src/main/java/com/dex/midi/ChordDriver.java
+++ b/src/main/java/com/dex/midi/ChordDriver.java
@@ -1,9 +1,6 @@
 package com.dex.midi;
 
-import com.dex.midi.chord.Chord;
-import com.dex.midi.chord.ChordEventListener;
-import com.dex.midi.chord.MidiChordListener;
-import com.dex.midi.chord.SimpleChordEventProducer;
+import com.dex.midi.chord.*;
 import com.dex.midi.event.MidiEventListenerSource;
 import com.dex.midi.util.SimpleLogger;
 
@@ -14,12 +11,9 @@ public class ChordDriver extends com.dex.midi.Driver implements ChordEventListen
 
 	@Override
 	public void init(MidiEventListenerSource p) {
-		SimpleChordEventProducer cp = new SimpleChordEventProducer();
-		
-		MidiChordListener l = new MidiChordListener(cp);
-		cp.addChordEventListener(this);
-		
-		p.addMidiEventListener(l);
+		MidiEventChordAdapter adapter = new MidiEventChordAdapter().registerListener(p);
+
+		adapter.addChordEventListener(this);
 	}
 	
 	@Override

--- a/src/main/java/com/dex/midi/ChordDriver.java
+++ b/src/main/java/com/dex/midi/ChordDriver.java
@@ -7,6 +7,7 @@ import com.dex.midi.util.SimpleLogger;
 import java.util.List;
 import java.util.logging.Level;
 
+@Deprecated
 public class ChordDriver extends com.dex.midi.Driver implements ChordEventListener {
 
 	@Override

--- a/src/main/java/com/dex/midi/Driver.java
+++ b/src/main/java/com/dex/midi/Driver.java
@@ -2,6 +2,7 @@ package com.dex.midi;
 
 import com.dex.midi.event.MidiEventListenerSource;
 import com.dex.midi.event.MidiEventException;
+import com.dex.midi.event.MidiEventObservableSource;
 import com.dex.midi.event.SimpleMidiEventProducer;
 import com.dex.midi.handler.PrintMidiEventListener;
 import com.dex.midi.util.SimpleLogger;
@@ -14,7 +15,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.logging.Level;
 
-public class Driver {
+public class Driver implements MidiDriver {
 	
 	private static final String EXIT = "exit";
 	
@@ -31,6 +32,16 @@ public class Driver {
 	}
 
 	public MidiEventListenerSource getMidiEventProducer() {
+		return SimpleMidiEventProducer.getInstance();
+	}
+
+	@Override
+	public MidiEventListenerSource getMidiEventListenerSource() {
+		return SimpleMidiEventProducer.getInstance();
+	}
+
+	@Override
+	public MidiEventObservableSource getMidiEventObservableSource() {
 		return SimpleMidiEventProducer.getInstance();
 	}
 
@@ -67,6 +78,7 @@ public class Driver {
 		}
 	}
 	
+	@Override
 	public void run() {
 		final String method = "run";
 		
@@ -100,6 +112,7 @@ public class Driver {
 		}
 	}
 	
+	@Override
 	public void close() {
 		final String method = "close";
 

--- a/src/main/java/com/dex/midi/MidiDriver.java
+++ b/src/main/java/com/dex/midi/MidiDriver.java
@@ -1,0 +1,12 @@
+package com.dex.midi;
+
+
+import com.dex.midi.event.MidiEventListenerSource;
+import com.dex.midi.event.MidiEventObservableSource;
+
+public interface MidiDriver extends Runnable, AutoCloseable {
+
+    MidiEventListenerSource getMidiEventListenerSource();
+
+    MidiEventObservableSource getMidiEventObservableSource();
+}

--- a/src/main/java/com/dex/midi/chord/MidiEventChordAdapter.java
+++ b/src/main/java/com/dex/midi/chord/MidiEventChordAdapter.java
@@ -1,0 +1,98 @@
+package com.dex.midi.chord;
+
+import com.dex.midi.event.*;
+import com.dex.midi.event.util.Disposables;
+import com.dex.midi.model.GuitarPositions;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.disposables.Disposable;
+
+import java.util.Collection;
+import java.util.List;
+
+public class MidiEventChordAdapter implements MidiEventListener, ChordEventObservableSource, ChordEventListenerSource {
+    final private SimpleChordEventProducer producer;
+    final private MidiChordListener listener;
+    private Disposable disposable;
+
+    public MidiEventChordAdapter() {
+        this(new SimpleChordEventProducer());
+    }
+
+    public MidiEventChordAdapter(SimpleChordEventProducer producer) {
+        this.producer = producer;
+        this.listener = new MidiChordListener(producer);
+    }
+
+    public MidiEventChordAdapter registerListener(MidiEventListenable listenable) {
+        listenable.addMidiEventListener(this);
+
+        return this;
+    }
+
+    public MidiEventChordAdapter registerObservable(MidiEventObservable observableSource) {
+        final Disposable newDisposable = Disposables.from(
+                observableSource.getNoteOnObservable().subscribe(this::noteOn),
+                observableSource.getNoteOffObservable().subscribe(this::noteOff),
+                observableSource.getPitchBendObservable().subscribe(this::pitchBend),
+                observableSource.getGuitarPositionObservable().subscribe(this::guitarPositions)
+        );
+
+        if (this.disposable == null || this.disposable.isDisposed()) {
+            this.disposable = newDisposable;
+        } else {
+            this.disposable = Disposables.from(
+                    this.disposable,
+                    newDisposable
+            );
+        }
+
+        return this;
+    }
+
+    @Override
+    public void addChordEventListener(ChordEventListener l) {
+        producer.addChordEventListener(l);
+    }
+
+    @Override
+    public void removeChordEventListener(ChordEventListener l) {
+        producer.removeChordEventListener(l);
+    }
+
+    @Override
+    public Observable<List<Chord>> getObservable() {
+        return producer.getObservable();
+    }
+
+    @Override
+    public void fireChordChange(List<Chord> chords) {
+        producer.fireChordChange(chords);
+    }
+
+    @Override
+    public void noteOn(PitchEvent e) {
+        listener.noteOn(e);
+    }
+
+    @Override
+    public void noteOff(PitchEvent e) {
+        listener.noteOff(e);
+    }
+
+    @Override
+    public void pitchBend(PitchBendEvent e) {
+        listener.pitchBend(e);
+    }
+
+    @Override
+    public void guitarPositions(GuitarPositions positions) {
+        listener.guitarPositions(positions);
+    }
+
+    @Override
+    public void close() {
+        producer.close();
+        listener.close();
+        disposable.dispose();
+    }
+}

--- a/src/main/java/com/dex/midi/util/CircularIterator.java
+++ b/src/main/java/com/dex/midi/util/CircularIterator.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public class CircularIterator<E> implements Iterator<E> {
 
-	private List<E> list;
+	final private List<E> list;
 	private int startIndex;
 	private int currentIndex;
 	

--- a/src/main/java/com/dex/midi/util/StatisticUtil.java
+++ b/src/main/java/com/dex/midi/util/StatisticUtil.java
@@ -8,10 +8,10 @@ public class StatisticUtil {
 		int total = 0;
 		
 		for (Integer i : list) {
-			total += i.intValue();
+			total += i;
 		}
 		
-		return total/list.size();
+		return (double) total / list.size();
 	}
 	
 	public static double standardDeviation(List<Integer> list) {
@@ -20,10 +20,10 @@ public class StatisticUtil {
 	
 	public static double standardDeviation(List<Integer> list, Double mean) {
 		if (mean == null) {
-			mean = Double.valueOf(StatisticUtil.mean(list));
+			mean = StatisticUtil.mean(list);
 		}
 		
-		double avg = mean.doubleValue();
+		double avg = mean;
 		
 		double diff = 0.0;
 		for (Integer i : list) {


### PR DESCRIPTION
- Particularly needed for mock implementation
- Also simplifies logic for ChordDriver (now deprecated)

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>