### PR TITLE
Update versions to build on latest macos arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # Midi Guitar
 
+Java library to convert raw MIDI events from guitar synthesizer pickup into guitar events.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,7 +8,7 @@
 
 plugins {
     // Apply the foojay-resolver plugin to allow automatic download of JDKs
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.9.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
 }
 
 rootProject.name = 'midi-guitar'


### PR DESCRIPTION
- Update gradle wrapper version to v9.0.0
- Update foojay-resolver-convention to version v1.0.0 to download correct JDK version for arm64 processor